### PR TITLE
fix: Prevent premature line wrapping of plant name

### DIFF
--- a/dist/fyta-plant-card.js
+++ b/dist/fyta-plant-card.js
@@ -563,7 +563,8 @@ class FytaPlantCard extends HTMLElement {
         font-weight: bold;
         width: calc(100% - 120px);
         margin-top: 8px;
-        text-transform: capitalize;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
         display: inline-block;
         cursor: pointer;
       }

--- a/dist/fyta-plant-card.js
+++ b/dist/fyta-plant-card.js
@@ -564,7 +564,7 @@ class FytaPlantCard extends HTMLElement {
         width: calc(100% - 120px);
         margin-top: 8px;
         text-transform: capitalize;
-        display: block;
+        display: inline-block;
         cursor: pointer;
       }
 


### PR DESCRIPTION
To go from this:
<img width="1137" alt="Bildschirmfoto 2025-05-12 um 15 58 25" src="https://github.com/user-attachments/assets/0a87e576-4a87-47f8-b4d3-6defffcbd249" />

to this:
<img width="1128" alt="Bildschirmfoto 2025-05-12 um 16 09 07" src="https://github.com/user-attachments/assets/f4f9aa6d-478c-43e8-bd7a-4157735ee9e7" />

